### PR TITLE
Prefer two-column indents for this project

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.tabSize": 2
+}


### PR DESCRIPTION
Visual Studio Code, by default, prefers 4-column indents. I do, too.

The JavaScript and React ecosystems, not unreasonably, prefer 2-column. I’d prefer to have only one indentation style in this codebase, not two.