### PR TITLE
Set initial dark-mode preference via matchMedia

### DIFF
--- a/src/hooks/useDarkMode.js
+++ b/src/hooks/useDarkMode.js
@@ -2,7 +2,8 @@ import { useEffect } from 'react';
 import useLocalStorage from './useLocalStorage';
 
 export const useDarkMode = (key, initialValue) => {
-  const [darkMode, setDarkMode] = useLocalStorage('darkMode', false);
+  const dmmql = window.matchMedia('(prefers-color-scheme: dark)');
+  const [darkMode, setDarkMode] = useLocalStorage('darkMode', dmmql.matches);
  
   useEffect(() => {
     darkMode


### PR DESCRIPTION
This change sets the initial state of useDarkMode to whatever the user’s browser says the user’s preference is.

As you might expect, fiddling with the toggle button still toggles between light and dark mode, and this state persists thanks to localStorage.